### PR TITLE
Fix backwards-comatibility issue

### DIFF
--- a/src/antidote_pb_codec.erl
+++ b/src/antidote_pb_codec.erl
@@ -364,6 +364,8 @@ encode_txn_properties(Props) ->
     exclusive_locks = proplists:get_value(exclusive_locks, Props, [])
   }.
 
+decode_txn_properties(undefined) ->
+  [];
 decode_txn_properties(#'ApbTxnProperties'{shared_locks = SharedLocks, exclusive_locks = ExclusiveLocks}) ->
   [{shared_locks, all_to_binary(SharedLocks)} || SharedLocks /= []]
   ++ [{exclusive_locks, all_to_binary(ExclusiveLocks)} || ExclusiveLocks /= []].


### PR DESCRIPTION
in older versions decode_txn_properties could be undefined, so addded a
clause for this case.

The Java client is affected, see https://github.com/AntidoteDB/antidote-java-client/issues/5